### PR TITLE
feat: strip p if only child

### DIFF
--- a/src/syntax/block.ts
+++ b/src/syntax/block.ts
@@ -167,8 +167,8 @@ export const MarkdownItMdcBlock: MarkdownIt.PluginSimple = (md) => {
         state.tokens.indexOf(tokenClose),
       )
         .filter(i => i.level === tokenOpen.level + 1)
-        .forEach((i) => {
-          if (i.tag === 'p')
+        .forEach((i, _, arr) => {
+          if (arr.length === 1 && i.tag === 'p')
             i.hidden = true
         })
 

--- a/src/syntax/block.ts
+++ b/src/syntax/block.ts
@@ -168,7 +168,7 @@ export const MarkdownItMdcBlock: MarkdownIt.PluginSimple = (md) => {
       )
         .filter(i => i.level === tokenOpen.level + 1)
         .forEach((i, _, arr) => {
-          if (arr.length === 1 && i.tag === 'p')
+          if (arr.length <= 2 && i.tag === 'p')
             i.hidden = true
         })
 

--- a/test/output/10.blocks-yaml.html
+++ b/test/output/10.blocks-yaml.html
@@ -5,7 +5,8 @@
   title="Nuxt Architecture."
   :items="[1, 2, []]"
   :data='{"foo":"bar","baz":"qux"}'
-  >Foo
+>
+  <p>Foo</p>
   <template #slot="">
     <p>Hello <strong>World</strong></p>
   </template>

--- a/test/output/3.blocks-slots.html
+++ b/test/output/3.blocks-slots.html
@@ -1,6 +1,6 @@
 <h1>Title</h1>
-<hero
-  >Default slot text
+<hero>
+  <p>Default slot text</p>
   <template #description="">
     <p>This will be rendered inside the <code>description</code> slot.</p>
   </template>

--- a/test/output/4.blocks-nesting.html
+++ b/test/output/4.blocks-nesting.html
@@ -1,6 +1,6 @@
 <hero>
-  <card
-    >A nested card
+  <card>
+    <p>A nested card</p>
     <card>A <strong>super</strong> nested card</card>
   </card>
 </hero>

--- a/test/output/9.blocks-slots.html
+++ b/test/output/9.blocks-slots.html
@@ -1,6 +1,6 @@
 <h1>Hello</h1>
-<hero
-  >Default slot text
+<hero>
+  <p>Default slot text</p>
   <template #description="">
     <p>This will be rendered inside the <code>description</code> slot.</p>
   </template>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Somewhat a followup on #2

Through this PR the stripping of `<p>` only happens if there is only one `p` and no other sibling in the parent.
Also see first paragraph of https://github.com/antfu/markdown-it-mdc/pull/2#issuecomment-1719335739

### Linked Issues

partially fixes #3, as paragraphs are not stripped when multiple ones are in a slot now.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
