### PR TITLE
fix: prev might be undefined

### DIFF
--- a/src/syntax/inline-props.ts
+++ b/src/syntax/inline-props.ts
@@ -98,7 +98,7 @@ export const MarkdownItInlineProps: MarkdownIt.PluginWithOptions<MdcInlinePropsO
         return
 
       const prev = tokens[index - 1]
-      if (prev.type !== 'mdc_block_open' || prev.tag !== 'ul')
+      if (!prev || prev.type !== 'mdc_block_open' || prev.tag !== 'ul')
         return
 
       // find the matching close token


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I got the following issue when adding a "bullet point only" slide in slidev

```
20:24:14 [vite] Internal server error: Cannot read properties of undefined (reading 'type')
  Plugin: unplugin-vue-markdown
  File: /@slidev/slides/6.md
      at file:///home/jdeniau/code/julien.deniau.me/public/open-source-howto/node_modules/markdown-it-mdc/dist/index.mjs:411:18
      at Array.forEach (<anonymous>)
      at MarkdownItInlineProps.md.parse (file:///home/jdeniau/code/julien.deniau.me/public/open-source-howto/node_modules/markdown-it-mdc/dist/index.mjs:406:12)
      at MarkdownIt.render (/home/jdeniau/code/julien.deniau.me/public/open-source-howto/node_modules/unplugin-vue-markdown/node_modules/markdown-it/lib/index.js:544:36)
      at file:///home/jdeniau/code/julien.deniau.me/public/open-source-howto/node_modules/unplugin-vue-markdown/dist/chunk-EES4WMNF.js:242:25
      at TransformContext.transform (file:///home/jdeniau/code/julien.deniau.me/public/open-source-howto/node_modules/unplugin-vue-markdown/dist/chunk-EES4WMNF.js:413:37)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Object.transform (file:///home/jdeniau/code/julien.deniau.me/public/open-source-howto/node_modules/vite/dist/node/chunks/dep-9A4-l-43.js:64063:30)
      at async loadAndTransform (file:///home/jdeniau/code/julien.deniau.me/public/open-source-howto/node_modules/vite/dist/node/chunks/dep-9A4-l-43.js:49741:29)
      at async viteTransformMiddleware (file:///home/jdeniau/code/julien.deniau.me/public/open-source-howto/node_modules/vite/dist/node/chunks/dep-9A4-l-43.js:59342:32
```

You can experiment yourself by creating a simple slide that only contains this

```

---
layout:default
---

*  test
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I do not really know why this is the plugin that is triggering the error, as I did not activate it, but testing that `prev`is defined does fix the issue.

I do not know how to test this though.
I did found [the following file](https://github.com/antfu/markdown-it-mdc/blob/main/test/input/14.list-handling.md?plain=1), but as I do not want to test MDC, what should I do here ?

### Workaround

encapsule the list in a `ul`:

```
::ul
- item 1
- item 2
::ul
```