### PR TITLE
fix: props without a trailing whitespace (#6)

### DIFF
--- a/src/parse/props.ts
+++ b/src/parse/props.ts
@@ -82,7 +82,6 @@ export function searchProps(content: string, index = 0) {
           ])
         }
       }
-      index += 1
     }
   }
 

--- a/test/input/6.inline-props.md
+++ b/test/input/6.inline-props.md
@@ -10,4 +10,4 @@ Hello World{class="text-green text-xl"}
 
 _italic_{style="color: blue"}
 
-**bold**{style="color: blue"}
+**bold**{style="color: blue"}!

--- a/test/input/7.inline-components.md
+++ b/test/input/7.inline-components.md
@@ -4,4 +4,4 @@ A simple :inline-component[John Doe]
 
 How to say :hello{}-world in Markdown
 
-Inline :component{key="value" key2=value2}
+Inline :component{key="value" key2=value2}!

--- a/test/input/8.inline-span.md
+++ b/test/input/8.inline-span.md
@@ -3,3 +3,5 @@ Hello [World]
 Hello [World]{.bg-blue-500}!
 
 Hello [World\] Yes]!
+
+Hello [World]{style=""}!

--- a/test/output/6.inline-props.html
+++ b/test/output/6.inline-props.html
@@ -10,4 +10,4 @@
 </p>
 <p><code style="color: red">code</code></p>
 <p><em style="color: blue">italic</em></p>
-<p><strong style="color: blue">bold</strong></p>
+<p><strong style="color: blue">bold</strong>!</p>

--- a/test/output/7.inline-components.html
+++ b/test/output/7.inline-components.html
@@ -1,4 +1,4 @@
 <p>A simple <inline-component /></p>
 <p>A simple <inline-component>John Doe</inline-component></p>
 <p>How to say <hello />-world in Markdown</p>
-<p>Inline <component key="value" key2="value2" /></p>
+<p>Inline <component key="value" key2="value2" />!</p>

--- a/test/output/8.inline-span.html
+++ b/test/output/8.inline-span.html
@@ -1,3 +1,4 @@
 <p>Hello <span>World</span></p>
 <p>Hello <span class="bg-blue-500">World</span>!</p>
 <p>Hello <span>World\] Yes</span>!</p>
+<p>Hello <span style="">World</span>!</p>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR fixes props without a trailing whitespace.

Examples:
```markdown
Hello [World]{prop}!
**bold**{style="color: blue"}!
Inline :component{key="value" key2=value2}!
```

Previously, it will be turned into:
```html
Hello <span prop="true" !="true">World</span>
<strong style="color: blue" !="true">bold</strong>
Inline <component key="value" key2="value2" !="true" />
```

In this PR:
```html
Hello <span prop="true">World</span>!
<strong style="color: blue">bold</strong>!
Inline <component key="value" key2="value2" />!
```

### Linked Issues

fix #6
fix https://github.com/slidevjs/slidev/issues/1234

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
