### PR TITLE
test: add test for embedded inline props

### DIFF
--- a/test/input/6.inline-props.md
+++ b/test/input/6.inline-props.md
@@ -11,3 +11,11 @@ Hello World{class="text-green text-xl"}
 _italic_{style="color: blue"}
 
 **bold**{style="color: blue"}!
+
+::card
+  Some sentence with non&nbsp;breaking&nbsp;spaces. A [link](./something.tar){download} with download inline props. Another sentence with non&nbsp;breaking&nbsp;spaces.
+::
+
+::card
+  A [link](./something.tar){download} with download inline props. Another [link](./something.tar) without inline props.
+::

--- a/test/output/6.inline-props.html
+++ b/test/output/6.inline-props.html
@@ -11,3 +11,12 @@
 <p><code style="color: red">code</code></p>
 <p><em style="color: blue">italic</em></p>
 <p><strong style="color: blue">bold</strong>!</p>
+<card
+  >Some sentence with non breaking spaces. A
+  <a href="./something.tar" download="true">link</a> with download inline props.
+  Another sentence with non&nbsp;breaking&nbsp;spaces.</card
+>
+<card
+  >A <a href="./something.tar" download="true">link</a> with download inline
+  props. Another <a href="./something.tar">link</a> without inline props.</card
+>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds additional tests (currently failing) for embedded inline props such as:

```md
::card
  Some sentence with non&nbsp;breaking&nbsp;spaces. A [link](./something.tar){download} with download inline props. sentence with non&nbsp;breaking&nbsp;spaces.
::

::card
  A [link](./something.tar){download} with download inline props. Another [link](./something.tar) without inline props.
::
```

### Linked Issues

#10