### PR TITLE
fix: rules shouldn't update `state.posMax`

### DIFF
--- a/src/syntax/inline-component.ts
+++ b/src/syntax/inline-component.ts
@@ -47,24 +47,17 @@ export const MarkdownItInlineComponent: MarkdownIt.PluginWithOptions<MdcInlineCo
     if (contentEnd !== contentStart) {
       const name = state.src.slice(start + 1, contentStart - 1)
       const body = state.src.slice(contentStart, contentEnd)
-      state.posMax = contentStart
       state.push('mdc_inline_component', name, 1)
-      state.pos = contentStart
-      state.posMax = contentEnd
       const text = state.push('text', '', 0)
       text.content = body
-      state.pos = contentEnd
-      state.posMax = contentEnd
       state.push('mdc_inline_component', name, -1)
     }
     else {
-      state.posMax = index
       const name = state.src.slice(start + 1, index)
       state.push('mdc_inline_component', name, 0)
     }
 
     state.pos = index
-    state.posMax = index
 
     return true
   })

--- a/src/syntax/inline-props.ts
+++ b/src/syntax/inline-props.ts
@@ -37,16 +37,12 @@ export const MarkdownItInlineProps: MarkdownIt.PluginWithOptions<MdcInlinePropsO
     if (silent)
       return true
 
-    state.pos = start
-    state.posMax = end
-
     // We insert a hidden token holding the props, and later apply them to the previous token
     const token = state.push('mdc_inline_props', 'span', 0)
     token.attrs = props
     token.hidden = true
 
     state.pos = end
-    state.posMax = end
 
     return true
   })

--- a/src/syntax/inline-span.ts
+++ b/src/syntax/inline-span.ts
@@ -27,21 +27,14 @@ export const MarkdownItInlineSpan: MarkdownIt.PluginWithOptions<MdcInlineSpanOpt
     if (silent)
       return true
 
-    state.posMax = start + 1
     state.push('mdc_inline_span', 'span', 1)
 
-    state.pos = start + 1
-    state.posMax = index
     const text = state.push('text', '', 0)
     text.content = state.src.slice(start + 1, index)
-
-    state.pos = index
-    state.posMax = index + 1
 
     state.push('mdc_inline_span', 'span', -1)
 
     state.pos = index + 1
-    state.posMax = index + 1
 
     return true
   })

--- a/test/input/7.inline-components.md
+++ b/test/input/7.inline-components.md
@@ -5,3 +5,7 @@ A simple :inline-component[John Doe]
 How to say :hello{}-world in Markdown
 
 Inline :component{key="value" key2=value2}!
+
+Inline :component and [link](https://example.com)!
+
+Inline :component[John Doe]{.cls} and _Italic_!

--- a/test/output/7.inline-components.html
+++ b/test/output/7.inline-components.html
@@ -2,3 +2,5 @@
 <p>A simple <inline-component>John Doe</inline-component></p>
 <p>How to say <hello />-world in Markdown</p>
 <p>Inline <component key="value" key2="value2" />!</p>
+<p>Inline <component /> and <a href="https://example.com">link</a>!</p>
+<p>Inline <component class="cls">John Doe</component> and <em>Italic</em>!</p>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

After investigations, it seems that the usage of `state.pos` and `state.posMax` was wrong. Roles shouldn't update `state.posMax` in common cases, and setting `state.pos` or `state.posMax` between `state.push(...)`s takes no effect. This PR removes the wrong/unnecessary settings of `state.pos` or `state.posMax`.

### Linked Issues

fix #10. fix https://github.com/slidevjs/slidev/issues/1625.

should close PR #9.

### Additional context

Couldn't find docs about `state.pos` or `state.posMax` anywhere. So I cannot guarantee the correctness 😭