### PR TITLE
test: add test for inline components with parameters at the beginning of a line

### DIFF
--- a/test/input/7.inline-components.md
+++ b/test/input/7.inline-components.md
@@ -9,3 +9,5 @@ Inline :component{key="value" key2=value2}!
 Inline :component and [link](https://example.com)!
 
 Inline :component[John Doe]{.cls} and _Italic_!
+
+:component{key="value" key2=value2} with params at the beginning of a line

--- a/test/output/7.inline-components.html
+++ b/test/output/7.inline-components.html
@@ -4,3 +4,4 @@
 <p>Inline <component key="value" key2="value2" />!</p>
 <p>Inline <component /> and <a href="https://example.com">link</a>!</p>
 <p>Inline <component class="cls">John Doe</component> and <em>Italic</em>!</p>
+<p><component key="value" key2="value2" /> with params at the beginning of a line</p>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds a test for the (currently failing) case of inline components with parameters at the beginning of a line.
I hope I'm doing it right but I'm not sure: it's my first PR on github and I only used `markdown-it-mdc` inside `sli.dev`.

### Linked Issues

#12 
