### PR TITLE
refactor: use parseYaml helper instead of direct js-yaml import

### DIFF
--- a/src/syntax/block.ts
+++ b/src/syntax/block.ts
@@ -1,7 +1,7 @@
 import type MarkdownIt from 'markdown-it'
 import type Token from 'markdown-it/lib/token.mjs'
-import { JSON_SCHEMA, load } from 'js-yaml'
 import { parseBlockParams } from '../parse/block-params'
+import { parseYaml } from '../parse/yaml'
 
 export const MarkdownItMdcBlock: MarkdownIt.PluginSimple = (md) => {
   const min_markers = 2
@@ -311,7 +311,7 @@ export const MarkdownItMdcBlock: MarkdownIt.PluginSimple = (md) => {
       if (!silent) {
         const yaml = state.src.slice(state.bMarks[startLine + 1], state.eMarks[lineEnd - 1])
 
-        const data = load(yaml, { schema: JSON_SCHEMA }) as Record<string, unknown>
+        const data = parseYaml(yaml)
         const token = state.env.mdcBlockTokens[0]
         Object.entries(data || {}).forEach(([key, value]) => {
           if (key === 'class')


### PR DESCRIPTION
# Description

small PR to refactor the code to use the yaml util