### PR TITLE
feat: add support for `yaml [props]` props syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ This plugin implements all the syntaxes documented in [Comark Syntax](https://co
 
 - [x] [Block Component](https://comark.dev/syntax/markdown#block-components)
   - [x] [Nesting](https://comark.dev/syntax/markdown#nested-components)
-  - [x] [YAML Props](https://comark.dev/syntax/markdown#yaml-props)
-  - [x] [Slots](https://comark.dev/syntax/markdown#component-slots)
-- [x] [Inline Components](https://comark.dev/syntax/markdown#inline-components)
+  - [x] [YAML Props](https://comark.dev/syntax/components#yaml-props-use-cases)
+  - [x] [Slots](https://comark.dev/syntax/components#component-slots)
+- [x] [Inline Components](https://comark.dev/syntax/components#inline-components)
 - [x] [Inline Props](https://comark.dev/syntax/markdown#attributes)
 - [x] [Span](https://comark.dev/syntax/markdown#span-text)
 - ~~Frontmatter~~. Frontmatter is not built-in in this plugin, we recommend using [`@mdit-vue/plugin-frontmatter`](https://github.com/mdit-vue/mdit-vue/tree/main/packages/plugin-frontmatter) if you want to use this plugin outside of Comark package,

--- a/src/syntax/block.ts
+++ b/src/syntax/block.ts
@@ -7,6 +7,13 @@ export const MarkdownItMdcBlock: MarkdownIt.PluginSimple = (md) => {
   const min_markers = 2
   const marker_str = ':'
   const marker_char = marker_str.charCodeAt(0)
+  const blockYamlLines: Record<string, string> = {
+    '---': '---',
+    '```yaml [props]': '```',
+    '~~~yaml [props]': '~~~',
+    '```yml [props]': '```',
+    '~~~yml [props]': '~~~',
+  }
 
   md.block.ruler.before(
     'fence',
@@ -291,7 +298,9 @@ export const MarkdownItMdcBlock: MarkdownIt.PluginSimple = (md) => {
       const end = state.eMarks[startLine]
 
       const line = state.src.slice(start, end)
-      if (line !== '---' && line !== '```yaml [props]')
+      const blockAttributesClosingFence = blockYamlLines[line] || ''
+
+      if (!blockAttributesClosingFence)
         return false
 
       let lineEnd = startLine + 1
@@ -299,7 +308,7 @@ export const MarkdownItMdcBlock: MarkdownIt.PluginSimple = (md) => {
       let found = false
       while (lineEnd < endLine) {
         const line = state.src.slice(state.bMarks[lineEnd] + state.tShift[startLine], state.eMarks[lineEnd])
-        if (line === '---' || line === '```') {
+        if (line === blockAttributesClosingFence) {
           found = true
           break
         }

--- a/src/syntax/block.ts
+++ b/src/syntax/block.ts
@@ -290,7 +290,8 @@ export const MarkdownItMdcBlock: MarkdownIt.PluginSimple = (md) => {
       const start = state.bMarks[startLine] + state.tShift[startLine]
       const end = state.eMarks[startLine]
 
-      if (state.src.slice(start, end) !== '---')
+      const line = state.src.slice(start, end)
+      if (line !== '---' && line !== '```yaml [props]')
         return false
 
       let lineEnd = startLine + 1
@@ -298,7 +299,7 @@ export const MarkdownItMdcBlock: MarkdownIt.PluginSimple = (md) => {
       let found = false
       while (lineEnd < endLine) {
         const line = state.src.slice(state.bMarks[lineEnd] + state.tShift[startLine], state.eMarks[lineEnd])
-        if (line === '---') {
+        if (line === '---' || line === '```') {
           found = true
           break
         }

--- a/test/input/10.blocks-yaml.md
+++ b/test/input/10.blocks-yaml.md
@@ -23,7 +23,7 @@ Hello **World**
 icon: IconNuxt
 description: Harness the full power of Nuxt and the Nuxt ecosystem.
 title: Nuxt Architecture.
-:items: "[1, 2, []]"
+:items: '[1, 2, []]'
 :data:
   foo: bar
   baz: qux
@@ -42,7 +42,7 @@ Hello **World**
 icon: IconNuxt
 description: Harness the full power of Nuxt and the Nuxt ecosystem.
 title: Nuxt Architecture.
-:items: "[1, 2, []]"
+:items: '[1, 2, []]'
 :data:
   foo: bar
   baz: qux

--- a/test/input/10.blocks-yaml.md
+++ b/test/input/10.blocks-yaml.md
@@ -54,3 +54,14 @@ Foo
 
 Hello **World**
 ::
+
+::landing-hero
+~~~yml [props]
+demoMarkdown: |-
+  ```ts [example.ts]
+  import { parse } from 'comark'
+
+  const tree = await parse('# Hello **World**')
+  ```
+~~~
+::

--- a/test/input/10.blocks-yaml.md
+++ b/test/input/10.blocks-yaml.md
@@ -17,3 +17,40 @@ Foo
 
 Hello **World**
 ::
+
+::icon-card
+```yaml [props]
+icon: IconNuxt
+description: Harness the full power of Nuxt and the Nuxt ecosystem.
+title: Nuxt Architecture.
+:items: "[1, 2, []]"
+:data:
+  foo: bar
+  baz: qux
+```
+
+Foo
+
+#slot
+
+Hello **World**
+::
+
+::icon-card
+
+```yaml [props]
+icon: IconNuxt
+description: Harness the full power of Nuxt and the Nuxt ecosystem.
+title: Nuxt Architecture.
+:items: "[1, 2, []]"
+:data:
+  foo: bar
+  baz: qux
+```
+
+Foo
+
+#slot
+
+Hello **World**
+::

--- a/test/output/10.blocks-yaml.html
+++ b/test/output/10.blocks-yaml.html
@@ -35,3 +35,10 @@
     <p>Hello <strong>World</strong></p>
   </template>
 </icon-card>
+<landing-hero
+  demoMarkdown="```ts [example.ts]
+import { parse } from 'comark'
+
+const tree = await parse('# Hello **World**')
+```"
+></landing-hero>

--- a/test/output/10.blocks-yaml.html
+++ b/test/output/10.blocks-yaml.html
@@ -11,3 +11,27 @@
     <p>Hello <strong>World</strong></p>
   </template>
 </icon-card>
+<icon-card
+  icon="IconNuxt"
+  description="Harness the full power of Nuxt and the Nuxt ecosystem."
+  title="Nuxt Architecture."
+  :items="[1, 2, []]"
+  :data='{"foo":"bar","baz":"qux"}'
+>
+  <p>Foo</p>
+  <template #slot="">
+    <p>Hello <strong>World</strong></p>
+  </template>
+</icon-card>
+<icon-card
+  icon="IconNuxt"
+  description="Harness the full power of Nuxt and the Nuxt ecosystem."
+  title="Nuxt Architecture."
+  :items="[1, 2, []]"
+  :data='{"foo":"bar","baz":"qux"}'
+>
+  <p>Foo</p>
+  <template #slot="">
+    <p>Hello <strong>World</strong></p>
+  </template>
+</icon-card>


### PR DESCRIPTION
There two syntaxes are same, and second one will be promoted and used by default, because it renderes good in all markdown renderes

## frontmatter style

```
::home-hero
---
primary:
  text: 38K+ GitHub stars
  url: https://github.com/nuxt/nuxt.js
---
::
```

::home-hero
---
primary:
  text: 38K+ GitHub stars
  url: https://github.com/nuxt/nuxt.js
---
::

## codeblock style

~~~
::home-hero
```yaml
primary:
  text: 38K+ GitHub stars
  url: https://github.com/nuxt/nuxt.js
```
::
~~~

::home-hero
```yaml
primary:
  text: 38K+ GitHub stars
  url: https://github.com/nuxt/nuxt.js
```
::