### PR TITLE
feat: add skipFootnoteLike option to inline span

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type MarkdownIt from 'markdown-it'
+import type { MdcInlineSpanOptions } from './syntax/inline-span'
 import { MarkdownItMdcBlock } from './syntax/block'
 import { MarkdownItInlineComponent } from './syntax/inline-component'
 import { MarkdownItInlineProps } from './syntax/inline-props'
@@ -26,10 +27,12 @@ export interface MarkdownItMdcOptions {
     /**
      * Enable inline span syntax.
      *
+     * Pass `true` to enable with defaults, or pass an object to configure.
+     *
      * @see https://content.nuxtjs.org/guide/writing/mdc#inline-span
      * @default true
      */
-    inlineSpan?: boolean
+    inlineSpan?: boolean | MdcInlineSpanOptions
     /**
      * Enable inline component syntax.
      *
@@ -54,8 +57,12 @@ const MarkdownItMdc: MarkdownIt.PluginWithOptions<MarkdownItMdcOptions> = (md, o
   if (inlineProps)
     md.use(MarkdownItInlineProps)
 
-  if (inlineSpan)
-    md.use(MarkdownItInlineSpan)
+  if (inlineSpan) {
+    const spanOptions = typeof inlineSpan === 'object'
+      ? inlineSpan
+      : {}
+    md.use(MarkdownItInlineSpan, spanOptions)
+  }
 
   if (inlineComponent)
     md.use(MarkdownItInlineComponent)

--- a/src/syntax/inline-span.ts
+++ b/src/syntax/inline-span.ts
@@ -1,15 +1,25 @@
 import type MarkdownIt from 'markdown-it'
 
 export interface MdcInlineSpanOptions {
-
+  /**
+   * Skip footnote-like syntax `[^...]` to avoid conflicts with footnote plugins.
+   *
+   * @default true
+   */
+  skipFootnoteLike?: boolean
 }
 
-export const MarkdownItInlineSpan: MarkdownIt.PluginWithOptions<MdcInlineSpanOptions> = (md) => {
+export const MarkdownItInlineSpan: MarkdownIt.PluginWithOptions<MdcInlineSpanOptions> = (md, options = {}) => {
+  const { skipFootnoteLike = true } = options
+
   md.inline.ruler.before('link', 'mdc_inline_span', (state, silent) => {
     const start = state.pos
     const char = state.src[start]
 
     if (char !== '[')
+      return false
+
+    if (skipFootnoteLike && state.src[start + 1] === '^')
       return false
 
     let index = start + 1

--- a/test/input/8.inline-span.md
+++ b/test/input/8.inline-span.md
@@ -5,3 +5,5 @@ Hello [World]{.bg-blue-500}!
 Hello [World\] Yes]!
 
 Hello [World]{style=""}!
+
+Test[^note]

--- a/test/output/8.inline-span.html
+++ b/test/output/8.inline-span.html
@@ -2,3 +2,4 @@
 <p>Hello <span class="bg-blue-500">World</span>!</p>
 <p>Hello <span>World] Yes</span>!</p>
 <p>Hello <span style="">World</span>!</p>
+<p>Test[^note]</p>


### PR DESCRIPTION
Adds a new option to mdc_inline_span that, when enabled, skips footnote-like syntax `[^...]` to avoid conflicts with footnote plugins (e.g. markdown-it-footnote).

By default, the option is `true`, which makes this PR a minor breaking change.

**Usage:**
```ts
md.use(MarkdownItMdc, { syntax: { inlineSpan: { skipFootnoteLike: true } } })
```

**Changes:**
- Added `skipFootnoteLike` option to `MdcInlineSpanOptions`
- Updated `MarkdownItMdc` to accept and pass options to inline span
- Added fixture test case for default behavior (`[^note]` still treated as span)

**Related issue:**
This fixes the footnote compatibility issue reported in https://github.com/slidevjs/slidev/issues/2524.